### PR TITLE
feat: MacClipyの運営・問い合わせ導線を追加

### DIFF
--- a/techguide/src/lib/contact/form.ts
+++ b/techguide/src/lib/contact/form.ts
@@ -1,4 +1,5 @@
 export const RECRUIT_CATEGORY_ID = 'recruit';
+export const MACCLIPY_CATEGORY_ID = 'macclipy';
 
 export const CONTACT_CATEGORIES = [
   { id: 'discovery', label: '課題整理・導入前の相談' },
@@ -10,6 +11,7 @@ export const CONTACT_CATEGORIES = [
   { id: 'partnership', label: '協業・パートナーの相談' },
   { id: RECRUIT_CATEGORY_ID, label: '採用・パートナー応募' },
   { id: 'media', label: '取材・登壇の相談' },
+  { id: MACCLIPY_CATEGORY_ID, label: 'MacClipyについて' },
   { id: 'sales', label: '営業・ご提案' },
   { id: 'other', label: 'その他・まだ整理できていない相談' },
 ] as const;

--- a/techguide/src/routes/contact/+page.svelte
+++ b/techguide/src/routes/contact/+page.svelte
@@ -4,6 +4,7 @@
   import { trackEvent } from '$lib/analytics';
   import {
     CONTACT_CATEGORIES,
+    MACCLIPY_CATEGORY_ID,
     RECRUIT_CATEGORY_ID,
     type ContactFieldErrors,
     type ContactCategoryId,
@@ -40,6 +41,7 @@
   }));
   const fieldErrors = $derived.by<ContactFieldErrors>(() => form?.fieldErrors ?? {});
   const isRecruit = $derived(selectedCategory === RECRUIT_CATEGORY_ID);
+  const isMacClipy = $derived(selectedCategory === MACCLIPY_CATEGORY_ID);
   const hasTurnstile = $derived(data.turnstileSiteKey.length > 0);
   const showSuccessPanel = $derived(!isSubmitting && form?.ok === true);
   const hideContactForm = $derived(isSubmitting || showSuccessPanel);
@@ -266,23 +268,37 @@
 
       <div class:contact-page__content--feedback={hideContactForm} class="contact-page__content">
         <div class="contact-page__details" hidden={hideContactForm}>
-          <section class="contact-page__panel">
-            <h2>このようなご相談に対応しています</h2>
-            <ul class="contact-page__support-list">
-              {#each contactPageContent.inquiryExamples as item (item)}
-                <li>{item}</li>
-              {/each}
-            </ul>
-          </section>
+          {#if isMacClipy}
+            <section class="contact-page__panel">
+              <h2>MacClipyについてお問い合わせいただけます</h2>
+              <p>
+                不具合、使い方、機能へのご要望を受け付けています。不具合の場合は、分かる範囲で次の情報もお知らせください。
+              </p>
+              <ul class="contact-page__support-list">
+                <li>お使いのmacOSとMacClipyのバージョン</li>
+                <li>問題が発生するまでの操作手順</li>
+                <li>表示されたメッセージや発生頻度</li>
+              </ul>
+            </section>
+          {:else}
+            <section class="contact-page__panel">
+              <h2>このようなご相談に対応しています</h2>
+              <ul class="contact-page__support-list">
+                {#each contactPageContent.inquiryExamples as item (item)}
+                  <li>{item}</li>
+                {/each}
+              </ul>
+            </section>
 
-          <section class="contact-page__panel">
-            <h2>{contactPageContent.processTitle}</h2>
-            <ol class="contact-page__process-list">
-              {#each contactPageContent.processSteps as step (step)}
-                <li>{step}</li>
-              {/each}
-            </ol>
-          </section>
+            <section class="contact-page__panel">
+              <h2>{contactPageContent.processTitle}</h2>
+              <ol class="contact-page__process-list">
+                {#each contactPageContent.processSteps as step (step)}
+                  <li>{step}</li>
+                {/each}
+              </ol>
+            </section>
+          {/if}
 
           <section class="contact-page__panel contact-page__panel--compact">
             <h2>返信について</h2>
@@ -430,7 +446,9 @@
               aria-describedby="message-help">{values.message ?? ''}</textarea
             >
             <em id="message-help">
-              現在の状況、相談したいこと、希望時期、参考URLなどを分かる範囲でご記入ください。
+              {isMacClipy
+                ? '不具合の場合は、macOS・MacClipyのバージョンと再現手順を分かる範囲でご記入ください。'
+                : '現在の状況、相談したいこと、希望時期、参考URLなどを分かる範囲でご記入ください。'}
             </em>
             {#if fieldErrors.message}
               <small>{fieldErrors.message}</small>

--- a/techguide/src/routes/macclipy/+page.svelte
+++ b/techguide/src/routes/macclipy/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { asset } from '$app/paths';
+  import { asset, resolve } from '$app/paths';
   import { trackEvent } from '$lib/analytics';
   import Footer from '$lib/components/layout/Footer.svelte';
   import Header from '$lib/components/layout/Header.svelte';
@@ -10,6 +10,8 @@
 
   const downloadHref = 'https://github.com/techguide-jp/mac-clipy/releases/latest';
   const sourceHref = 'https://github.com/techguide-jp/mac-clipy';
+  const companyHref = resolve('/#company');
+  const contactHref = resolve('/contact/?category=macclipy&subject=MacClipyについて');
   const images = {
     hero: '/images/macclipy/macclipy-web-hero-rich.webp',
     workflow: '/images/macclipy/macclipy-workflow-rich.webp',
@@ -63,6 +65,10 @@
       link_label: 'MacClipyを無料でダウンロード',
       destination_host: 'github.com',
     });
+  }
+
+  function trackContact() {
+    trackEvent('contact_cta_click', { placement: 'macclipy_support' });
   }
 </script>
 
@@ -225,6 +231,25 @@
           最新版をダウンロード
         </a>
         <p>Developer ID署名・Apple公証済みのDMGをGitHub Releasesから配布しています。</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section support" aria-labelledby="support-title">
+    <div class="container support__inner">
+      <div class="support__copy">
+        <p class="section-label">Operator &amp; support</p>
+        <h2 id="support-title">運営・サポート</h2>
+        <p>
+          MacClipyは、{companyProfile.name}が開発・運営しています。不具合、使い方、機能へのご要望は専用フォームからお問い合わせいただけます。
+        </p>
+      </div>
+
+      <div class="support__actions">
+        <a class="support__company-link" href={companyHref}>運営者情報を見る</a>
+        <a class="download-button" href={contactHref} onclick={trackContact}>
+          MacClipyについて問い合わせる
+        </a>
       </div>
     </div>
   </section>

--- a/techguide/src/routes/macclipy/macclipy.css
+++ b/techguide/src/routes/macclipy/macclipy.css
@@ -498,6 +498,49 @@
   font-size: 0.84rem;
 }
 
+.support {
+  color: #eaf3ee;
+  background: #101915;
+}
+
+.support__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: clamp(36px, 6vw, 90px);
+  align-items: center;
+}
+
+.support .section-label {
+  color: #88d8aa;
+}
+
+.support__copy > p:last-child {
+  max-width: 42rem;
+  margin-top: 20px;
+  color: rgba(229, 240, 234, 0.7);
+}
+
+.support__actions {
+  display: flex;
+  min-width: 300px;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.support__company-link {
+  color: rgba(238, 247, 242, 0.8);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: rgba(158, 230, 188, 0.45);
+  text-underline-offset: 6px;
+}
+
+.support__company-link:hover {
+  color: #ffffff;
+}
+
 @media (max-width: 900px) {
   .macclipy-page h1 {
     font-size: 5rem;
@@ -523,8 +566,14 @@
   .workflow__inner,
   .features__layout,
   .privacy__inner,
-  .install__inner {
+  .install__inner,
+  .support__inner {
     grid-template-columns: 1fr;
+  }
+
+  .support__actions {
+    min-width: 0;
+    justify-content: flex-start;
   }
 
   .workflow__copy {
@@ -579,6 +628,11 @@
     align-items: flex-start;
     flex-direction: column;
     gap: 18px;
+  }
+
+  .support__actions {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .hero__facts {


### PR DESCRIPTION
## 概要
- MacClipy公式ページに、TechGuide合同会社が開発・運営していることを明示する「運営・サポート」セクションを追加
- 既存のお問い合わせフォームに「MacClipyについて」カテゴリを追加
- MacClipy専用URLからカテゴリと件名を初期選択し、不具合・使い方・要望向けの案内を表示
- 専用CTAを既存の `contact_cta_click` / `macclipy_support` で計測

## 既存実装の調整意図
- 問い合わせカテゴリは既存の `CONTACT_CATEGORIES` に追加し、既存の型生成・サーバー検証・管理者メール生成をそのまま利用しています。新しいAPIやDBを増やさず、カテゴリ判定のずれを防ぐためです。
- 問い合わせページは選択カテゴリに応じて案内だけを切り替え、既存の必須項目と送信処理は維持しています。製品問い合わせ専用フォームを重複実装しないためです。
- 内部リンクはSvelteKitの `resolve()` を使い、base pathやtrailing slashの既存ルールに従っています。

## 利用者への影響
- 配布前に運営主体を確認できます。
- アプリや公式ページから、MacClipyカテゴリと件名が入力済みの問い合わせフォームへ移動できます。
- 不具合報告時に必要なバージョン・再現手順の案内が表示されます。

## 検証
- `pnpm validate`
- PC幅・390px幅で `/macclipy/` のレイアウトを確認
- 専用URLのカテゴリ・件名初期値を確認
- カテゴリ切替と開発用mock送信完了を確認
- ブラウザconsole errorがないことを確認

## リリース順
このPRを先にマージ・公開し、MacClipyアプリ側PRの問い合わせリンクを受けられる状態にします。