### PR TITLE
feat: MacClipy匿名計測APIとプライバシー説明を追加

### DIFF
--- a/techguide/.env.example
+++ b/techguide/.env.example
@@ -4,19 +4,22 @@
 # - 環境設定: PUBLIC_GA_MEASUREMENT_ID, PUBLIC_TURNSTILE_SITE_KEY,
 #   RESEND_FROM_NAME, RESEND_FROM_EMAIL, CONTACT_TO_EMAIL, AMPLIFY_AWS_REGION,
 #   必要に応じて AMPLIFY_APP_ID / AMPLIFY_SECRET_PATH_PREFIX
-# - シークレット: RESEND_API_KEY, TURNSTILE_SECRET_KEY
+# - シークレット: MACCLIPY_GA_API_SECRET, RESEND_API_KEY, TURNSTILE_SECRET_KEY
 #
 # PUBLIC_ で始まる値は SvelteKit の build 時に公開bundleへ埋め込まれます。
 # RESEND_FROM_NAME / RESEND_FROM_EMAIL / CONTACT_TO_EMAIL はサーバーbundleへ
 # build時に埋め込み、SSR actionから参照します。
 # Amplifyでこれらの値を変更した場合は、反映に再デプロイが必要です。
 #
-# RESEND_API_KEY / TURNSTILE_SECRET_KEY を Amplify の「シークレット」に置く場合、
+# MACCLIPY_GA_API_SECRET / RESEND_API_KEY / TURNSTILE_SECRET_KEY を
+# Amplify の「シークレット」に置く場合、
 # SSR Compute role に対象SSM Parameter Storeの ssm:GetParameter 権限が必要です。
 # このアプリの共有シークレットは通常 `/amplify/shared/d1ei4wu36fr0u9/<KEY>` から読みます。
 #
 # GA4_PROPERTY_ID と GOOGLE_APPLICATION_CREDENTIALS は GA4 管理スクリプト用です。
 # Amplify の通常デプロイでは設定不要です。
+# MACCLIPY_GA_API_SECRET はMacClipyの匿名起動イベントをMeasurement Protocolへ
+# 転送するサーバー専用シークレットです。公開bundleへ含めないでください。
 #
 # サーバー側コードは通常の runtime 環境変数、build時に埋め込む非secret値、
 # Amplify shared secret のSSM Parameter Store参照に対応しています。
@@ -29,6 +32,7 @@
 # CONTACT_DEV_MOCK_SUBMISSION=false にすると、ローカルでも実際のTurnstile/Resend連携を検証します。
 
 PUBLIC_GA_MEASUREMENT_ID=G-MS3VSF32XF
+MACCLIPY_GA_API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxx
 GA4_PROPERTY_ID=123456789
 GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service-account.json
 CONTACT_DEV_MOCK_SUBMISSION=true

--- a/techguide/README.md
+++ b/techguide/README.md
@@ -27,6 +27,12 @@ pnpm build
   支援内容の詳細ページ
 - `/contact`  
   Resend を使った独自問い合わせフォーム
+- `/macclipy`
+  MacClipyの製品・ダウンロード案内
+- `/macclipy/privacy`
+  MacClipyのプライバシーポリシー
+- `/api/macclipy/analytics`
+  署名済みMacClipyから匿名イベントを受け取るAPI
 
 ## 主な編集ポイント
 
@@ -111,18 +117,19 @@ legacy の [../events/index.html](../events/index.html) は rollback や参照�
 - 旧 URL の redirect / rewrite は Amplify コンソール側で維持する
 - 日常運用では `techguide/` を更新すれば本番と `redirects` に反映される
 - GA4 は `PUBLIC_GA_MEASUREMENT_ID` を設定し、`techguide.jp` / `www.techguide.jp` の本番ホストでのみ有効化する
+- MacClipyの匿名イベント転送には、サーバー専用の `MACCLIPY_GA_API_SECRET` が必要。構築・確認・障害対応は [docs/macclipy-analytics.md](./docs/macclipy-analytics.md) に従う
 - Resend を使う問い合わせフォームには `RESEND_API_KEY`、`RESEND_FROM_NAME`、`RESEND_FROM_EMAIL`、`CONTACT_TO_EMAIL`、`PUBLIC_TURNSTILE_SITE_KEY`、`TURNSTILE_SECRET_KEY` が必要
 - `PUBLIC_*` は SvelteKit の build 時に公開bundleへ埋め込むため、Amplifyで値を変えたら再デプロイが必要
 - `RESEND_FROM_NAME`、`RESEND_FROM_EMAIL`、`CONTACT_TO_EMAIL` はAmplifyの「環境設定」に置き、サーバーbundleへbuild時に埋め込んでSSR actionから参照する。変更時は再デプロイが必要
-- `RESEND_API_KEY` と `TURNSTILE_SECRET_KEY` は公開bundleへ入れず、AmplifyのシークレットまたはSSR runtime環境変数からサーバー側だけで読む
-- Amplifyの「シークレット」に置く場合は、SSR Compute role にSSM Parameter Storeの `ssm:GetParameter` 権限を付ける。現在の共有シークレットは `/amplify/shared/d1ei4wu36fr0u9/RESEND_API_KEY` と `/amplify/shared/d1ei4wu36fr0u9/TURNSTILE_SECRET_KEY` を読む想定
+- `MACCLIPY_GA_API_SECRET`、`RESEND_API_KEY`、`TURNSTILE_SECRET_KEY` は公開bundleへ入れず、AmplifyのシークレットまたはSSR runtime環境変数からサーバー側だけで読む
+- Amplifyの「シークレット」に置く場合は、SSR Compute role にSSM Parameter Storeの `ssm:GetParameter` 権限を付ける。現在の共有シークレットは `/amplify/shared/d1ei4wu36fr0u9/MACCLIPY_GA_API_SECRET`、`/amplify/shared/d1ei4wu36fr0u9/RESEND_API_KEY`、`/amplify/shared/d1ei4wu36fr0u9/TURNSTILE_SECRET_KEY` を読む想定
 - `pnpm dev` では `CONTACT_DEV_MOCK_SUBMISSION` が未設定または `true` の場合、送信完了UIを確認しやすいようにTurnstile/Resendを呼ばず成功扱いにする。ローカルで実連携を検証する場合は `CONTACT_DEV_MOCK_SUBMISSION=false` にする
 - AWS は SvelteKit 用 adapter を自社保守していないため、Amplify のSSR対応はコミュニティ adapter の `amplify-adapter` に依存しています
 - `design/TechGuide/` と `events/` は legacy / rollback 参照用として残している
 
 ### SSR Compute role
 
-問い合わせフォームの server action は、Turnstile secret と Resend API key をサーバー側で参照します。Amplify Console の「シークレット」に置いた値は、SvelteKit SSR compute の `process.env` にはそのまま出ないため、SSR Compute role 経由でSSM Parameter Storeから読みます。
+問い合わせフォームのserver actionとMacClipyの匿名計測APIは、秘密値をサーバー側で参照します。Amplify Console の「シークレット」に置いた値は、SvelteKit SSR compute の `process.env` にはそのまま出ないため、SSR Compute role 経由でSSM Parameter Storeから読みます。
 
 SSR Compute role に付ける最小権限の例:
 
@@ -134,6 +141,7 @@ SSR Compute role に付ける最小権限の例:
       "Effect": "Allow",
       "Action": "ssm:GetParameter",
       "Resource": [
+        "arn:aws:ssm:ap-northeast-1:953573378652:parameter/amplify/shared/d1ei4wu36fr0u9/MACCLIPY_GA_API_SECRET",
         "arn:aws:ssm:ap-northeast-1:953573378652:parameter/amplify/shared/d1ei4wu36fr0u9/RESEND_API_KEY",
         "arn:aws:ssm:ap-northeast-1:953573378652:parameter/amplify/shared/d1ei4wu36fr0u9/TURNSTILE_SECRET_KEY"
       ]
@@ -192,6 +200,7 @@ GA4 の管理作業は、公式クライアント `@google-analytics/admin` を�
 
 - `contact_page_view` の Key event 化
 - `placement`, `section`, `link_label`, `destination_host` の custom dimension 作成・更新
+- MacClipy用の `app_version`, `build_number`, `macos_major_version`, `architecture` の custom dimension 作成・更新
 
 事前準備:
 
@@ -210,6 +219,7 @@ cp .env.example .env
 
 ```dotenv
 PUBLIC_GA_MEASUREMENT_ID=G-MS3VSF32XF
+MACCLIPY_GA_API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxx
 GA4_PROPERTY_ID=123456789
 GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service-account.json
 RESEND_API_KEY=re_xxxxxxxxx

--- a/techguide/docs/macclipy-analytics.md
+++ b/techguide/docs/macclipy-analytics.md
@@ -1,0 +1,134 @@
+# MacClipy 匿名利用状況の運用手順
+
+`POST /api/macclipy/analytics` は、MacClipyから匿名イベントを受け取り、GA4 Measurement Protocolへ転送します。クリップボードの内容や検索語は受け付けません。
+
+## 計測仕様
+
+| アプリのイベント | GA4イベント             | 頻度                    | 主な用途                   |
+| ---------------- | ----------------------- | ----------------------- | -------------------------- |
+| `install`        | `macclipy_install`      | インストールIDごとに1回 | ユニークインストールの目安 |
+| `daily_active`   | `macclipy_daily_active` | 1日1回まで              | DAU・WAU・MAUの目安        |
+
+共通パラメータは `app_version`、`build_number`、`macos_major_version`、`architecture` です。ランダムなインストールIDをGA4の `client_id` として使います。広告関連の同意状態は常に拒否として転送します。
+
+インストールIDは個人やWebサイトのCookieに結び付けません。再インストール後もキーチェーンのIDが残る場合があるため、インストール数は厳密なダウンロード数ではありません。また、送信を停止した利用者は集計されません。
+
+## 本番設定
+
+### 1. Measurement ProtocolのAPI secret
+
+GA4の対象データストリームでMeasurement Protocol API secretを発行します。値は公開環境変数に置かず、Amplifyの共有シークレットとして次のパスへ保存します。
+
+```text
+/amplify/shared/d1ei4wu36fr0u9/MACCLIPY_GA_API_SECRET
+```
+
+SSR Compute roleには、このパラメータに対する `ssm:GetParameter` を追加します。
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "ssm:GetParameter",
+  "Resource": "arn:aws:ssm:ap-northeast-1:953573378652:parameter/amplify/shared/d1ei4wu36fr0u9/MACCLIPY_GA_API_SECRET"
+}
+```
+
+`PUBLIC_GA_MEASUREMENT_ID` は対象Webストリームの測定IDにします。API secretをログ、PR、クライアントの `Info.plist`、公開bundleへ出力しないでください。
+
+### 2. GA4 custom dimension
+
+サービスアカウントと `GA4_PROPERTY_ID` を設定し、差分確認後に反映します。
+
+```bash
+pnpm ga:sync:dry
+pnpm ga:sync
+pnpm ga:list
+```
+
+次のイベントスコープdimensionが作成されます。
+
+- `app_version`
+- `build_number`
+- `macos_major_version`
+- `architecture`
+
+### 3. 保存期間
+
+MacClipyの送信を有効にする前に、GA4プロパティのイベント単位・ユーザー単位データ保持期間を14か月に設定します。
+
+Amplify Hosting compute logsを保持する場合は30日以内にします。CloudWatch Logsを利用している環境では次のように設定し、実際のポリシーを確認します。
+
+```bash
+aws logs put-retention-policy \
+  --log-group-name /aws/amplify/<app-id> \
+  --retention-in-days 30 \
+  --region ap-northeast-1
+```
+
+API実装はイベントを独自DBへ保存しません。レート制限に使う接続元IPアドレスはプロセスのメモリ内だけに置き、最長60秒で期限切れにします。
+
+## 検証
+
+### ローカルAPI
+
+`pnpm dev` ではGA4へ転送せず、検証済みのリクエストを `202` で受理します。
+
+```bash
+curl -i http://127.0.0.1:5173/api/macclipy/analytics \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "schema_version": 1,
+    "installation_id": "a4b69d19-9b90-4dad-b034-f4a3fc912fa1",
+    "event_name": "install",
+    "app_version": "0.2.0",
+    "build_number": "20",
+    "macos_major_version": 26,
+    "architecture": "arm64",
+    "occurred_at": "<現在から5分以内のUTC時刻>"
+  }'
+```
+
+期待結果は本文なしの `202 Accepted` です。形式不正は `400`、大きすぎる本文は `413`、JSON以外は `415`、短時間の連続送信は `429`、GA4転送失敗は `503` です。
+
+### GA4連携
+
+本番反映前は、GoogleのMeasurement Protocol validation serverでペイロードを検証します。validation serverはイベントをGA4レポートへ記録しません。
+
+- [Measurement Protocol validation server](https://developers.google.com/analytics/devguides/collection/protocol/ga4/validating-events)
+- [Measurement Protocolの送信仕様](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events)
+
+本番反映後は、署名済みMacClipyの検証用インストール1台から送信し、次を確認します。
+
+1. 初回起動後、GA4のリアルタイムに `macclipy_install` と `macclipy_daily_active` が各1件現れる。
+2. 同じ日に再起動しても `macclipy_daily_active` が増えない。
+3. 設定で匿名送信をオフにした後はAPIリクエストが発生しない。
+4. GA4に `app_version` など4つのパラメータが入り、クリップボード由来の値がない。
+
+## 集計と見方
+
+GA4の探索またはレポートで、Web側のCTAとアプリ利用を分けて見ます。
+
+- ダウンロード導線: Webイベント `outbound_link_click`
+- ユニークインストールの目安: `macclipy_install` のユーザー数・イベント数
+- DAU・WAU・MAUの目安: `macclipy_daily_active` の期間別ユーザー数
+- バージョン分布: `macclipy_daily_active` を `app_version` と `build_number` で分解
+- 対応環境: `macos_major_version` と `architecture` で分解
+
+CTAクリック、GitHubのダウンロード、インストール、アクティブ利用は定義が異なるため、同じ数値として扱いません。取得不能や転送失敗も0件として扱わず、APIの `503` とHosting compute logsを確認します。API secretやリクエスト本文はログへ出しません。
+
+## 障害・不正利用への対応
+
+- アプリは送信失敗で主要機能を止めず、次回起動時に未送信イベントを再試行します。
+- APIは1アドレス・1分あたり10件、保持キー1万件までを各SSRプロセスで制限します。上限到達時は新規アドレスを拒否します。
+- 複数インスタンスをまたぐ大量アクセスには、この制限だけでは不十分です。継続的な不正利用がある場合はAWS WAFなどのホスティング側制限を追加します。
+- GA4転送が連続して失敗する場合は、測定ID、API secret、SSM権限、Google側の応答を順に確認します。secretの値そのものは出力しません。
+
+## リリース順序
+
+1. このAPIと `/macclipy/privacy/` を本番へ反映する。
+2. GA4の保持期間、API secret、custom dimension、ログ保持期間を確認する。
+3. validation serverと検証用インストールで疎通を確認する。
+4. 匿名送信を有効にした署名・公証済みMacClipyをリリースする。
+5. 初回24時間はAPIエラーとGA4リアルタイムを確認する。
+
+APIやポリシーが未反映の状態では、MacClipy側の匿名送信を有効にしません。ローカルビルドと未署名ビルドは実装上も送信無効です。

--- a/techguide/package.json
+++ b/techguide/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "svelte-kit sync && eslint . --fix --max-warnings 0",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "validate": "pnpm format:check && pnpm lint && pnpm check && pnpm build",
+    "validate": "pnpm format:check && pnpm lint && pnpm check && pnpm test && pnpm build",
     "ga:list": "node --env-file-if-exists=.env scripts/ga-admin.mjs list",
     "ga:sync": "node --env-file-if-exists=.env scripts/ga-admin.mjs sync",
     "ga:sync:dry": "node --env-file-if-exists=.env scripts/ga-admin.mjs sync --dry-run",

--- a/techguide/package.json
+++ b/techguide/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "node --disable-warning=ExperimentalWarning --test src/lib/server/macclipy/*.test.ts",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "svelte-kit sync && eslint . --max-warnings 0",

--- a/techguide/scripts/ga-admin.mjs
+++ b/techguide/scripts/ga-admin.mjs
@@ -34,6 +34,30 @@ const DEFAULT_CUSTOM_DIMENSIONS = [
     description: 'クリック先のホスト名',
     scope: CustomDimension.DimensionScope.EVENT,
   },
+  {
+    parameterName: 'app_version',
+    displayName: 'MacClipy app version',
+    description: 'MacClipyのアプリバージョン',
+    scope: CustomDimension.DimensionScope.EVENT,
+  },
+  {
+    parameterName: 'build_number',
+    displayName: 'MacClipy build number',
+    description: 'MacClipyのビルド番号',
+    scope: CustomDimension.DimensionScope.EVENT,
+  },
+  {
+    parameterName: 'macos_major_version',
+    displayName: 'macOS major version',
+    description: 'MacClipyを利用したmacOSのメジャーバージョン',
+    scope: CustomDimension.DimensionScope.EVENT,
+  },
+  {
+    parameterName: 'architecture',
+    displayName: 'MacClipy architecture',
+    description: 'MacClipyを利用したCPUアーキテクチャ',
+    scope: CustomDimension.DimensionScope.EVENT,
+  },
 ];
 
 function fail(message) {

--- a/techguide/src/lib/data/site.ts
+++ b/techguide/src/lib/data/site.ts
@@ -31,7 +31,15 @@ export const siteMetadata: SiteMetadata = {
 export const instagramProfileUrl = 'https://www.instagram.com/yuchan_314/';
 
 export const pageSeo: Record<
-  'home' | 'services' | 'articles' | 'contact' | 'instagram' | 'profile' | 'recruit' | 'macclipy',
+  | 'home'
+  | 'services'
+  | 'articles'
+  | 'contact'
+  | 'instagram'
+  | 'profile'
+  | 'recruit'
+  | 'macclipy'
+  | 'macclipyPrivacy',
   PageSeo
 > = {
   home: {
@@ -90,6 +98,12 @@ export const pageSeo: Record<
     path: '/macclipy/',
     image: '/images/macclipy/macclipy-og-rich.png',
     imageAlt: 'MacClipyのコピー履歴パネルを表示したMacBook',
+  },
+  macclipyPrivacy: {
+    title: 'MacClipy プライバシーポリシー | TechGuide',
+    description:
+      'MacClipyが取り扱うデータ、匿名の利用状況の送信内容、利用目的、停止方法、保存期間について説明します。',
+    path: '/macclipy/privacy/',
   },
 };
 

--- a/techguide/src/lib/server/env.ts
+++ b/techguide/src/lib/server/env.ts
@@ -7,7 +7,11 @@ import {
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 
 const DEFAULT_AMPLIFY_APP_ID = 'd1ei4wu36fr0u9';
-const SSM_SECRET_NAMES = new Set(['RESEND_API_KEY', 'TURNSTILE_SECRET_KEY']);
+const SSM_SECRET_NAMES = new Set([
+  'MACCLIPY_GA_API_SECRET',
+  'RESEND_API_KEY',
+  'TURNSTILE_SECRET_KEY',
+]);
 const BUILD_TIME_SERVER_ENV: Record<string, string | undefined> = {
   CONTACT_TO_EMAIL: STATIC_CONTACT_TO_EMAIL,
   RESEND_FROM_EMAIL: STATIC_RESEND_FROM_EMAIL,

--- a/techguide/src/lib/server/macclipy/analyticsEndpoint.test.ts
+++ b/techguide/src/lib/server/macclipy/analyticsEndpoint.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleMacClipyAnalyticsRequest } from './analyticsEndpoint.ts';
+
+const validPayload = {
+  schema_version: 1,
+  installation_id: 'a4b69d19-9b90-4dad-b034-f4a3fc912fa1',
+  event_name: 'install',
+  app_version: '0.2.0',
+  build_number: '20',
+  macos_major_version: 26,
+  architecture: 'arm64',
+  occurred_at: '2026-07-20T02:59:00Z',
+};
+
+const now = new Date('2026-07-20T03:00:00Z');
+
+await test('accepts a valid payload and forwards it once', async () => {
+  let forwardCalls = 0;
+  const result = await handleMacClipyAnalyticsRequest(makeInput(JSON.stringify(validPayload)), {
+    now: () => now,
+    consumeRateLimit: () => true,
+    forward: () => {
+      forwardCalls += 1;
+      return Promise.resolve();
+    },
+  });
+
+  assert.equal(result.status, 202);
+  assert.equal(forwardCalls, 1);
+});
+
+await test('rejects non-JSON, oversized, and malformed requests before forwarding', async () => {
+  let forwardCalls = 0;
+  const dependencies = {
+    now: () => now,
+    consumeRateLimit: () => true,
+    forward: () => {
+      forwardCalls += 1;
+      return Promise.resolve();
+    },
+  };
+
+  const nonJson = await handleMacClipyAnalyticsRequest(
+    { ...makeInput('{}'), contentType: 'text/plain' },
+    dependencies,
+  );
+  const jsonPrefixOnly = await handleMacClipyAnalyticsRequest(
+    { ...makeInput(JSON.stringify(validPayload)), contentType: 'application/jsonp' },
+    dependencies,
+  );
+  const oversized = await handleMacClipyAnalyticsRequest(
+    { ...makeInput('{}'), contentLength: 4_097 },
+    dependencies,
+  );
+  const malformed = await handleMacClipyAnalyticsRequest(makeInput('{'), dependencies);
+
+  assert.equal(nonJson.status, 415);
+  assert.equal(jsonPrefixOnly.status, 415);
+  assert.equal(oversized.status, 413);
+  assert.equal(malformed.status, 400);
+  assert.equal(forwardCalls, 0);
+});
+
+await test('returns 429 without forwarding when rate limited', async () => {
+  let forwardCalls = 0;
+  const result = await handleMacClipyAnalyticsRequest(makeInput(JSON.stringify(validPayload)), {
+    now: () => now,
+    consumeRateLimit: () => false,
+    forward: () => {
+      forwardCalls += 1;
+      return Promise.resolve();
+    },
+  });
+
+  assert.equal(result.status, 429);
+  assert.equal(result.headers?.['Retry-After'], '60');
+  assert.equal(forwardCalls, 0);
+});
+
+await test('returns a generic 503 without echoing payload or secret', async () => {
+  const result = await handleMacClipyAnalyticsRequest(makeInput(JSON.stringify(validPayload)), {
+    now: () => now,
+    consumeRateLimit: () => true,
+    forward: () => Promise.reject(new Error('server-only-secret')),
+  });
+
+  assert.equal(result.status, 503);
+  assert.equal(JSON.stringify(result).includes('server-only-secret'), false);
+  assert.equal(JSON.stringify(result).includes(validPayload.installation_id), false);
+});
+
+function makeInput(bodyText: string) {
+  return {
+    contentType: 'application/json',
+    contentLength: new TextEncoder().encode(bodyText).byteLength,
+    bodyText,
+    clientAddress: '192.0.2.1',
+  };
+}

--- a/techguide/src/lib/server/macclipy/analyticsEndpoint.ts
+++ b/techguide/src/lib/server/macclipy/analyticsEndpoint.ts
@@ -1,0 +1,65 @@
+import {
+  parseMacClipyAnalyticsPayload,
+  type MacClipyAnalyticsPayload,
+} from './analyticsValidation.ts';
+
+export const MAX_ANALYTICS_BODY_BYTES = 4_096;
+
+interface AnalyticsEndpointInput {
+  contentType: string | null;
+  contentLength: number | null;
+  bodyText: string;
+  clientAddress: string;
+}
+
+interface AnalyticsEndpointDependencies {
+  now?: () => Date;
+  consumeRateLimit(clientAddress: string): boolean;
+  forward(payload: MacClipyAnalyticsPayload): Promise<void>;
+}
+
+export interface AnalyticsEndpointResult {
+  status: 202 | 400 | 413 | 415 | 429 | 503;
+  headers?: Record<string, string>;
+}
+
+export async function handleMacClipyAnalyticsRequest(
+  input: AnalyticsEndpointInput,
+  dependencies: AnalyticsEndpointDependencies,
+): Promise<AnalyticsEndpointResult> {
+  const mediaType = input.contentType?.split(';', 1)[0]?.trim().toLowerCase();
+  if (mediaType !== 'application/json') {
+    return { status: 415 };
+  }
+
+  const actualLength = new TextEncoder().encode(input.bodyText).byteLength;
+  if (
+    (input.contentLength !== null && input.contentLength > MAX_ANALYTICS_BODY_BYTES) ||
+    actualLength > MAX_ANALYTICS_BODY_BYTES
+  ) {
+    return { status: 413 };
+  }
+
+  if (!dependencies.consumeRateLimit(input.clientAddress)) {
+    return { status: 429, headers: { 'Retry-After': '60' } };
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(input.bodyText);
+  } catch {
+    return { status: 400 };
+  }
+
+  const validation = parseMacClipyAnalyticsPayload(value, dependencies.now?.() ?? new Date());
+  if (!validation.ok) {
+    return { status: 400 };
+  }
+
+  try {
+    await dependencies.forward(validation.payload);
+    return { status: 202 };
+  } catch {
+    return { status: 503 };
+  }
+}

--- a/techguide/src/lib/server/macclipy/analyticsRateLimit.test.ts
+++ b/techguide/src/lib/server/macclipy/analyticsRateLimit.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createAnalyticsRateLimiter } from './analyticsRateLimit.ts';
+
+await test('allows the configured number of requests within a window', () => {
+  let now = 1_000;
+  const limiter = createAnalyticsRateLimiter({
+    limit: 2,
+    windowMs: 60_000,
+    maxEntries: 100,
+    now: () => now,
+  });
+
+  assert.equal(limiter.consume('client-a'), true);
+  assert.equal(limiter.consume('client-a'), true);
+  assert.equal(limiter.consume('client-a'), false);
+
+  now += 60_001;
+  assert.equal(limiter.consume('client-a'), true);
+});
+
+await test('bounds stored keys and fails closed for new keys at capacity', () => {
+  const limiter = createAnalyticsRateLimiter({
+    limit: 1,
+    windowMs: 60_000,
+    maxEntries: 2,
+    now: () => 1_000,
+  });
+
+  assert.equal(limiter.consume('client-a'), true);
+  assert.equal(limiter.consume('client-b'), true);
+  assert.equal(limiter.consume('client-c'), false);
+});

--- a/techguide/src/lib/server/macclipy/analyticsRateLimit.ts
+++ b/techguide/src/lib/server/macclipy/analyticsRateLimit.ts
@@ -1,0 +1,60 @@
+interface AnalyticsRateLimiterOptions {
+  limit: number;
+  windowMs: number;
+  maxEntries: number;
+  now?: () => number;
+}
+
+interface AnalyticsRateLimitEntry {
+  count: number;
+  windowStartedAt: number;
+}
+
+export interface AnalyticsRateLimiter {
+  consume(key: string): boolean;
+}
+
+export function createAnalyticsRateLimiter({
+  limit,
+  windowMs,
+  maxEntries,
+  now = Date.now,
+}: AnalyticsRateLimiterOptions): AnalyticsRateLimiter {
+  const entries = new Map<string, AnalyticsRateLimitEntry>();
+
+  return {
+    consume(key: string): boolean {
+      const currentTime = now();
+      removeExpiredEntries(entries, currentTime, windowMs);
+
+      const existing = entries.get(key);
+      if (existing) {
+        if (existing.count >= limit) {
+          return false;
+        }
+
+        existing.count += 1;
+        return true;
+      }
+
+      if (entries.size >= maxEntries) {
+        return false;
+      }
+
+      entries.set(key, { count: 1, windowStartedAt: currentTime });
+      return true;
+    },
+  };
+}
+
+function removeExpiredEntries(
+  entries: Map<string, AnalyticsRateLimitEntry>,
+  currentTime: number,
+  windowMs: number,
+): void {
+  for (const [key, entry] of entries) {
+    if (currentTime - entry.windowStartedAt >= windowMs) {
+      entries.delete(key);
+    }
+  }
+}

--- a/techguide/src/lib/server/macclipy/analyticsValidation.test.ts
+++ b/techguide/src/lib/server/macclipy/analyticsValidation.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseMacClipyAnalyticsPayload } from './analyticsValidation.ts';
+
+const now = new Date('2026-07-20T03:00:00.000Z');
+const validPayload = {
+  schema_version: 1,
+  installation_id: 'a4b69d19-9b90-4dad-b034-f4a3fc912fa1',
+  event_name: 'install',
+  app_version: '0.2.0',
+  build_number: '20',
+  macos_major_version: 26,
+  architecture: 'arm64',
+  occurred_at: '2026-07-20T02:59:00Z',
+};
+
+await test('accepts the exact anonymous analytics schema', () => {
+  const result = parseMacClipyAnalyticsPayload(validPayload, now);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.payload.installationId, validPayload.installation_id);
+    assert.equal(result.payload.eventName, 'install');
+  }
+});
+
+await test('rejects unknown fields including clipboard contents', () => {
+  const result = parseMacClipyAnalyticsPayload(
+    { ...validPayload, clipboard_text: 'private value' },
+    now,
+  );
+
+  assert.deepEqual(result, { ok: false, reason: 'invalid_schema' });
+});
+
+await test('rejects invalid identifiers, event names, and architectures', () => {
+  for (const override of [
+    { installation_id: 'not-a-uuid' },
+    { event_name: 'clipboard_copy' },
+    { architecture: 'universal' },
+  ]) {
+    assert.equal(parseMacClipyAnalyticsPayload({ ...validPayload, ...override }, now).ok, false);
+  }
+});
+
+await test('rejects timestamps older than 72 hours or too far in the future', () => {
+  const stale = { ...validPayload, occurred_at: '2026-07-16T02:59:00Z' };
+  const future = { ...validPayload, occurred_at: '2026-07-20T03:06:00Z' };
+
+  assert.equal(parseMacClipyAnalyticsPayload(stale, now).ok, false);
+  assert.equal(parseMacClipyAnalyticsPayload(future, now).ok, false);
+});
+
+await test('rejects malformed app and operating-system metadata', () => {
+  for (const override of [
+    { app_version: 'version two' },
+    { build_number: '../20' },
+    { macos_major_version: 13 },
+  ]) {
+    assert.equal(parseMacClipyAnalyticsPayload({ ...validPayload, ...override }, now).ok, false);
+  }
+});

--- a/techguide/src/lib/server/macclipy/analyticsValidation.ts
+++ b/techguide/src/lib/server/macclipy/analyticsValidation.ts
@@ -1,0 +1,107 @@
+export type MacClipyAnalyticsEventName = 'install' | 'daily_active';
+export type MacClipyArchitecture = 'arm64' | 'x86_64';
+
+export interface MacClipyAnalyticsPayload {
+  schemaVersion: 1;
+  installationId: string;
+  eventName: MacClipyAnalyticsEventName;
+  appVersion: string;
+  buildNumber: string;
+  macOSMajorVersion: number;
+  architecture: MacClipyArchitecture;
+  occurredAt: Date;
+}
+
+export type MacClipyAnalyticsValidationResult =
+  | { ok: true; payload: MacClipyAnalyticsPayload }
+  | { ok: false; reason: 'invalid_schema' };
+
+const REQUIRED_KEYS = new Set([
+  'schema_version',
+  'installation_id',
+  'event_name',
+  'app_version',
+  'build_number',
+  'macos_major_version',
+  'architecture',
+  'occurred_at',
+]);
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const VERSION_PATTERN = /^\d{1,4}(?:\.\d{1,4}){1,3}(?:[-+][0-9A-Za-z.-]{1,24})?$/;
+const BUILD_PATTERN = /^[0-9A-Za-z._-]{1,32}$/;
+const MAX_EVENT_AGE_MS = 72 * 60 * 60 * 1_000;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+
+export function parseMacClipyAnalyticsPayload(
+  value: unknown,
+  now: Date = new Date(),
+): MacClipyAnalyticsValidationResult {
+  if (!isRecord(value) || !hasExactKeys(value)) {
+    return invalid();
+  }
+
+  const schemaVersion = value.schema_version;
+  const installationId = value.installation_id;
+  const eventName = value.event_name;
+  const appVersion = value.app_version;
+  const buildNumber = value.build_number;
+  const macOSMajorVersion = value.macos_major_version;
+  const architecture = value.architecture;
+  const occurredAtValue = value.occurred_at;
+
+  if (
+    schemaVersion !== 1 ||
+    typeof installationId !== 'string' ||
+    !UUID_PATTERN.test(installationId) ||
+    (eventName !== 'install' && eventName !== 'daily_active') ||
+    typeof appVersion !== 'string' ||
+    !VERSION_PATTERN.test(appVersion) ||
+    typeof buildNumber !== 'string' ||
+    !BUILD_PATTERN.test(buildNumber) ||
+    !Number.isInteger(macOSMajorVersion) ||
+    typeof macOSMajorVersion !== 'number' ||
+    macOSMajorVersion < 14 ||
+    macOSMajorVersion > 99 ||
+    (architecture !== 'arm64' && architecture !== 'x86_64') ||
+    typeof occurredAtValue !== 'string'
+  ) {
+    return invalid();
+  }
+
+  const occurredAt = new Date(occurredAtValue);
+  const eventAge = now.getTime() - occurredAt.getTime();
+  if (
+    !Number.isFinite(occurredAt.getTime()) ||
+    eventAge > MAX_EVENT_AGE_MS ||
+    eventAge < -MAX_FUTURE_SKEW_MS
+  ) {
+    return invalid();
+  }
+
+  return {
+    ok: true,
+    payload: {
+      schemaVersion,
+      installationId: installationId.toLowerCase(),
+      eventName,
+      appVersion,
+      buildNumber,
+      macOSMajorVersion,
+      architecture,
+      occurredAt,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value);
+  return keys.length === REQUIRED_KEYS.size && keys.every((key) => REQUIRED_KEYS.has(key));
+}
+
+function invalid(): MacClipyAnalyticsValidationResult {
+  return { ok: false, reason: 'invalid_schema' };
+}

--- a/techguide/src/lib/server/macclipy/gaMeasurementClient.test.ts
+++ b/techguide/src/lib/server/macclipy/gaMeasurementClient.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sendMacClipyAnalyticsEvent } from './gaMeasurementClient.ts';
+import type { MacClipyAnalyticsPayload } from './analyticsValidation.ts';
+
+const payload: MacClipyAnalyticsPayload = {
+  schemaVersion: 1,
+  installationId: 'a4b69d19-9b90-4dad-b034-f4a3fc912fa1',
+  eventName: 'daily_active',
+  appVersion: '0.2.0',
+  buildNumber: '20',
+  macOSMajorVersion: 26,
+  architecture: 'arm64',
+  occurredAt: new Date('2026-07-20T02:59:00Z'),
+};
+
+await test('maps the installation id to GA client_id and denies advertising consent', async () => {
+  let requestUrl = '';
+  let requestBody = '';
+
+  await sendMacClipyAnalyticsEvent(
+    payload,
+    { measurementId: 'G-TEST123', apiSecret: 'server-only-secret' },
+    (input, init) => {
+      requestUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (typeof init?.body !== 'string') {
+        return Promise.reject(new Error('expected_string_request_body'));
+      }
+      requestBody = init.body;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    },
+  );
+
+  const url = new URL(requestUrl);
+  const body = JSON.parse(requestBody) as Record<string, unknown>;
+  const events = body.events as Array<{ name: string; params: Record<string, unknown> }>;
+
+  assert.equal(url.origin + url.pathname, 'https://www.google-analytics.com/mp/collect');
+  assert.equal(url.searchParams.get('measurement_id'), 'G-TEST123');
+  assert.equal(url.searchParams.get('api_secret'), 'server-only-secret');
+  assert.equal(body.client_id, payload.installationId);
+  assert.deepEqual(body.consent, {
+    ad_user_data: 'DENIED',
+    ad_personalization: 'DENIED',
+  });
+  assert.equal(events[0]?.name, 'macclipy_daily_active');
+  assert.deepEqual(events[0]?.params, {
+    app_version: '0.2.0',
+    build_number: '20',
+    macos_major_version: 26,
+    architecture: 'arm64',
+    session_id: 1_784_516_340,
+    engagement_time_msec: 1,
+  });
+  assert.equal(requestBody.includes('clipboard'), false);
+});
+
+await test('throws without exposing the API secret when GA rejects the request', async () => {
+  await assert.rejects(
+    sendMacClipyAnalyticsEvent(
+      payload,
+      { measurementId: 'G-TEST123', apiSecret: 'server-only-secret' },
+      () => Promise.resolve(new Response(null, { status: 500 })),
+    ),
+    (error: unknown) => {
+      assert.equal(error instanceof Error, true);
+      assert.equal(String(error).includes('server-only-secret'), false);
+      return true;
+    },
+  );
+});

--- a/techguide/src/lib/server/macclipy/gaMeasurementClient.ts
+++ b/techguide/src/lib/server/macclipy/gaMeasurementClient.ts
@@ -1,0 +1,58 @@
+import type { MacClipyAnalyticsPayload } from './analyticsValidation.ts';
+
+interface GaMeasurementConfiguration {
+  measurementId: string;
+  apiSecret: string;
+}
+
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export async function sendMacClipyAnalyticsEvent(
+  payload: MacClipyAnalyticsPayload,
+  configuration: GaMeasurementConfiguration,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const measurementId = configuration.measurementId.trim();
+  const apiSecret = configuration.apiSecret.trim();
+  if (!measurementId || !apiSecret) {
+    throw new Error('ga_measurement_not_configured');
+  }
+
+  const url = new URL('https://www.google-analytics.com/mp/collect');
+  url.searchParams.set('measurement_id', measurementId);
+  url.searchParams.set('api_secret', apiSecret);
+
+  const eventName = payload.eventName === 'install' ? 'macclipy_install' : 'macclipy_daily_active';
+  const sessionId = Math.floor(payload.occurredAt.getTime() / 1_000);
+  const body = {
+    client_id: payload.installationId,
+    timestamp_micros: payload.occurredAt.getTime() * 1_000,
+    consent: {
+      ad_user_data: 'DENIED',
+      ad_personalization: 'DENIED',
+    },
+    events: [
+      {
+        name: eventName,
+        params: {
+          app_version: payload.appVersion,
+          build_number: payload.buildNumber,
+          macos_major_version: payload.macOSMajorVersion,
+          architecture: payload.architecture,
+          session_id: sessionId,
+          engagement_time_msec: 1,
+        },
+      },
+    ],
+  };
+
+  const response = await fetcher(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(3_000),
+  });
+  if (!response.ok) {
+    throw new Error('ga_measurement_failed');
+  }
+}

--- a/techguide/src/routes/api/macclipy/analytics/+server.ts
+++ b/techguide/src/routes/api/macclipy/analytics/+server.ts
@@ -1,0 +1,96 @@
+import { dev } from '$app/environment';
+import { PUBLIC_GA_MEASUREMENT_ID } from '$env/static/public';
+import { getServerEnv } from '$lib/server/env';
+import {
+  handleMacClipyAnalyticsRequest,
+  MAX_ANALYTICS_BODY_BYTES,
+} from '$lib/server/macclipy/analyticsEndpoint';
+import { createAnalyticsRateLimiter } from '$lib/server/macclipy/analyticsRateLimit';
+import { sendMacClipyAnalyticsEvent } from '$lib/server/macclipy/gaMeasurementClient';
+import type { RequestHandler } from './$types';
+
+export const prerender = false;
+
+const rateLimiter = createAnalyticsRateLimiter({
+  limit: 10,
+  windowMs: 60_000,
+  maxEntries: 10_000,
+});
+
+export const POST: RequestHandler = async ({ request, getClientAddress }) => {
+  const declaredLength = readContentLength(request.headers.get('content-length'));
+  if (declaredLength !== null && declaredLength > MAX_ANALYTICS_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+
+  const bodyText = await readBoundedBody(request);
+  if (bodyText === null) {
+    return new Response(null, { status: 413 });
+  }
+
+  const result = await handleMacClipyAnalyticsRequest(
+    {
+      contentType: request.headers.get('content-type'),
+      contentLength: declaredLength,
+      bodyText,
+      clientAddress: getClientAddress(),
+    },
+    {
+      consumeRateLimit: (clientAddress) => rateLimiter.consume(clientAddress),
+      forward: async (payload) => {
+        if (dev) {
+          return;
+        }
+
+        const apiSecret = await getServerEnv('MACCLIPY_GA_API_SECRET');
+        await sendMacClipyAnalyticsEvent(payload, {
+          measurementId: PUBLIC_GA_MEASUREMENT_ID,
+          apiSecret: apiSecret ?? '',
+        });
+      },
+    },
+  );
+
+  return new Response(null, { status: result.status, headers: result.headers });
+};
+
+async function readBoundedBody(request: Request): Promise<string | null> {
+  if (!request.body) {
+    return '';
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_ANALYTICS_BODY_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function readContentLength(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}

--- a/techguide/src/routes/macclipy/+page.svelte
+++ b/techguide/src/routes/macclipy/+page.svelte
@@ -12,6 +12,7 @@
   const sourceHref = 'https://github.com/techguide-jp/mac-clipy';
   const companyHref = resolve('/#company');
   const contactHref = resolve('/contact/?category=macclipy&subject=MacClipyについて');
+  const privacyHref = resolve('/macclipy/privacy/');
   const images = {
     hero: '/images/macclipy/macclipy-web-hero-rich.webp',
     workflow: '/images/macclipy/macclipy-workflow-rich.webp',
@@ -186,6 +187,7 @@
         <p>
           コピー履歴データはMac内に保存されます。パスワード管理アプリやプライベートな作業アプリは、履歴保存の対象外に設定できます。
         </p>
+        <p><a class="privacy__policy-link" href={privacyHref}>プライバシーポリシーを見る</a></p>
       </div>
 
       <figure class="section-visual">
@@ -247,6 +249,7 @@
 
       <div class="support__actions">
         <a class="support__company-link" href={companyHref}>運営者情報を見る</a>
+        <a class="support__company-link" href={privacyHref}>プライバシーポリシー</a>
         <a class="download-button" href={contactHref} onclick={trackContact}>
           MacClipyについて問い合わせる
         </a>

--- a/techguide/src/routes/macclipy/macclipy.css
+++ b/techguide/src/routes/macclipy/macclipy.css
@@ -441,10 +441,24 @@
   align-items: center;
 }
 
-.privacy__copy > p:last-child {
+.privacy__copy > h2 + p {
   max-width: 38rem;
   margin-top: 22px;
   color: #5f6a63;
+}
+
+.privacy__policy-link {
+  display: inline-block;
+  margin-top: 18px;
+  color: #236b45;
+  font-weight: 750;
+  text-decoration: underline;
+  text-decoration-color: rgba(35, 107, 69, 0.4);
+  text-underline-offset: 5px;
+}
+
+.privacy__policy-link:hover {
+  color: #174c30;
 }
 
 .install__inner {

--- a/techguide/src/routes/macclipy/privacy/+page.svelte
+++ b/techguide/src/routes/macclipy/privacy/+page.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import Footer from '$lib/components/layout/Footer.svelte';
+  import Header from '$lib/components/layout/Header.svelte';
+  import SeoHead from '$lib/components/seo/SeoHead.svelte';
+  import { companyProfile, navItems, pageSeo } from '$lib/data/site';
+  import { buildBreadcrumbJsonLd, buildWebPageJsonLd, serializeJsonLd } from '$lib/seo';
+
+  const productHref = resolve('/macclipy/');
+  const contactHref = resolve('/contact/?category=macclipy&subject=MacClipyのプライバシーについて');
+  const structuredData = [
+    buildWebPageJsonLd({
+      name: pageSeo.macclipyPrivacy.title,
+      description: pageSeo.macclipyPrivacy.description,
+      path: pageSeo.macclipyPrivacy.path,
+      type: 'WebPage',
+    }),
+    buildBreadcrumbJsonLd([
+      { name: 'ホーム', path: '/' },
+      { name: 'MacClipy', path: pageSeo.macclipy.path },
+      { name: 'プライバシーポリシー', path: pageSeo.macclipyPrivacy.path },
+    ]),
+  ].map((item) => serializeJsonLd(item));
+</script>
+
+<SeoHead
+  title={pageSeo.macclipyPrivacy.title}
+  description={pageSeo.macclipyPrivacy.description}
+  path={pageSeo.macclipyPrivacy.path}
+  jsonLd={structuredData}
+/>
+
+<Header items={navItems} />
+
+<main class="privacy-page">
+  <header class="privacy-hero">
+    <div class="container privacy-hero__inner">
+      <p class="privacy-hero__eyebrow">MacClipy</p>
+      <h1>プライバシーポリシー</h1>
+      <p>MacClipyが取り扱うデータと、匿名の利用状況を送信する目的・範囲・停止方法を説明します。</p>
+      <p class="privacy-hero__date">制定・最終更新：2026年7月20日</p>
+    </div>
+  </header>
+
+  <div class="container privacy-layout">
+    <nav class="privacy-toc" aria-label="このページの目次">
+      <p>目次</p>
+      <ol>
+        <li><a href="#local-data">Mac内に保存するデータ</a></li>
+        <li><a href="#analytics-data">送信する匿名データ</a></li>
+        <li><a href="#purpose">利用目的</a></li>
+        <li><a href="#opt-out">送信を停止する方法</a></li>
+        <li><a href="#processors">外部サービス</a></li>
+        <li><a href="#retention">保存期間</a></li>
+        <li><a href="#contact">お問い合わせ</a></li>
+      </ol>
+    </nav>
+
+    <article class="privacy-content">
+      <section class="privacy-summary" aria-labelledby="summary-title">
+        <h2 id="summary-title">要点</h2>
+        <ul>
+          <li>コピー履歴、お気に入り、フォルダ名、検索語は外部へ送信しません。</li>
+          <li>製品改善のため、個人を直接特定しない最小限の利用状況を初期設定で送信します。</li>
+          <li>送信はMacClipyの設定からいつでも停止できます。</li>
+          <li>広告目的の利用、他サービスをまたぐ追跡、データ販売は行いません。</li>
+        </ul>
+      </section>
+
+      <section id="local-data">
+        <h2>1. Mac内に保存するデータ</h2>
+        <p>
+          コピー履歴、お気に入り、フォルダ、除外アプリなど、MacClipyの主要な機能に必要なデータは利用者のMac内に保存します。これらの内容をTechGuideのサーバーやGoogle
+          Analyticsへ送信することはありません。
+        </p>
+        <p>
+          匿名計測に使うランダムなインストールIDはmacOSのキーチェーンに保存します。このIDには、氏名、メールアドレス、端末名、Apple
+          IDなどを含めません。
+        </p>
+      </section>
+
+      <section id="analytics-data">
+        <h2>2. 送信する匿名データ</h2>
+        <p>匿名の利用状況が有効な場合、次の情報だけを送信します。</p>
+        <ul>
+          <li>ランダムに生成したインストールID</li>
+          <li>イベント種別（初回利用、1日1回までのアクティブ利用）</li>
+          <li>アプリのバージョンとビルド番号</li>
+          <li>macOSのメジャーバージョン</li>
+          <li>CPUアーキテクチャ（Apple SiliconまたはIntel）</li>
+          <li>イベントの発生日時</li>
+        </ul>
+        <p>
+          クリップボードの内容、検索語、ファイル、ウインドウ名、利用中のアプリ名、氏名、メールアドレス、端末名、正確なOSバージョンは送信しません。WebサイトのCookieとインストールIDを結び付けることもありません。
+        </p>
+      </section>
+
+      <section id="purpose">
+        <h2>3. 利用目的</h2>
+        <p>送信されたデータは、次の目的に限って利用します。</p>
+        <ul>
+          <li>おおよそのインストール数、日次・週次・月次の利用状況を把握するため</li>
+          <li>利用中のバージョンや環境を把握し、更新・互換性対応を判断するため</li>
+          <li>不具合や利用率の変化を検知し、製品とサポートを改善するため</li>
+        </ul>
+      </section>
+
+      <section id="opt-out">
+        <h2>4. 送信を停止する方法</h2>
+        <p>
+          匿名の利用状況は初期設定で有効です。MacClipyの「設定」→「一般」→「匿名の利用状況を送信する」をオフにすると、それ以降の送信を停止できます。オフにした状態でも、クリップボード履歴などの機能はそのまま利用できます。
+        </p>
+        <p>
+          設定をオフにしても、Mac内のキーチェーンに保存されたインストールIDは自動では削除されません。ただし、オフの間はそのIDを読み出して送信しません。
+        </p>
+      </section>
+
+      <section id="processors">
+        <h2>5. 外部サービスとデータの取扱い</h2>
+        <p>
+          アプリはTechGuideが管理する受信APIへデータを送信し、受信APIからGoogle Analytics
+          4へサーバー間で転送します。Googleへ利用者のIPアドレスを転送せず、広告関連の同意状態を「拒否」として送信します。
+        </p>
+        <p>
+          受信APIはAWS Amplify
+          Hosting上で動作します。通信の提供や障害対応のため、GoogleおよびAWSのインフラでデータが処理される場合があります。各社の取扱いは、
+          <a href="https://policies.google.com/privacy" rel="external noreferrer"
+            >Google プライバシーポリシー</a
+          >
+          および
+          <a href="https://aws.amazon.com/jp/privacy/" rel="external noreferrer">AWS プライバシー</a
+          >
+          をご確認ください。
+        </p>
+        <p>当社は、この匿名データを販売せず、広告配信や他社サービスをまたぐ追跡に利用しません。</p>
+      </section>
+
+      <section id="retention">
+        <h2>6. 保存期間と安全管理</h2>
+        <p>
+          Google
+          Analytics上のイベント単位・ユーザー単位データは14か月で削除する設定とします。集計済みの統計値は、個々のインストールを識別しない形でそれより長く残る場合があります。
+        </p>
+        <p>
+          受信APIは、送信されたイベントを独自のデータベースへ保存しません。不正な連続送信を抑えるため、接続元IPアドレスをプロセスのメモリ内だけで最長60秒間利用し、Google
+          Analyticsへは転送しません。障害・不正利用の調査でホスティングのアクセスログを保管する場合は、30日以内に削除します。
+        </p>
+        <p>
+          個人情報と結び付かないランダムIDであるため、当社は特定の利用者のデータを検索できません。今後の送信は、上記の設定をオフにすることで停止できます。
+        </p>
+      </section>
+
+      <section>
+        <h2>7. ポリシーの変更</h2>
+        <p>
+          送信項目や利用目的を変更する場合は、このページを更新し、重要な変更はアプリまたは配布ページでお知らせします。変更後の内容は、このページに表示した更新日から適用します。
+        </p>
+      </section>
+
+      <section id="contact">
+        <h2>8. お問い合わせ</h2>
+        <p>
+          本ポリシーやMacClipyのデータ取扱いについては、<a href={contactHref}
+            >お問い合わせフォーム</a
+          >からご連絡ください。
+        </p>
+      </section>
+
+      <a class="back-link" href={productHref}>MacClipyのページへ戻る</a>
+    </article>
+  </div>
+</main>
+
+<Footer companyName={companyProfile.name} items={navItems} />
+
+<style>
+  .privacy-page {
+    color: var(--color-ink);
+  }
+
+  .privacy-hero {
+    padding-block: clamp(64px, 9vw, 110px);
+    border-bottom: 1px solid var(--color-line);
+    background:
+      radial-gradient(circle at 80% 20%, rgba(230, 184, 92, 0.2), transparent 34%),
+      linear-gradient(145deg, #fffdf8 0%, #faf3e2 100%);
+  }
+
+  .privacy-hero__inner {
+    max-width: 900px;
+  }
+
+  .privacy-hero__eyebrow {
+    margin-bottom: 12px;
+    color: var(--color-primary-deep);
+    font-size: 0.84rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .privacy-hero h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2.25rem, 6vw, 4.5rem);
+    line-height: 1.15;
+    letter-spacing: -0.04em;
+  }
+
+  .privacy-hero h1 + p {
+    max-width: 720px;
+    margin-top: 24px;
+    color: var(--color-ink-soft);
+    font-size: clamp(1rem, 2vw, 1.15rem);
+  }
+
+  .privacy-hero__date {
+    margin-top: 18px;
+    color: var(--color-ink-soft);
+    font-size: 0.88rem;
+  }
+
+  .privacy-layout {
+    display: grid;
+    grid-template-columns: minmax(180px, 250px) minmax(0, 760px);
+    gap: clamp(44px, 7vw, 92px);
+    justify-content: center;
+    padding-block: clamp(56px, 8vw, 100px);
+  }
+
+  .privacy-toc {
+    position: sticky;
+    top: calc(var(--header-height) + 28px);
+    align-self: start;
+    padding: 24px;
+    border: 1px solid var(--color-line);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .privacy-toc > p {
+    font-weight: 800;
+  }
+
+  .privacy-toc ol {
+    display: grid;
+    gap: 10px;
+    margin: 14px 0 0;
+    padding-left: 1.25rem;
+    color: var(--color-ink-soft);
+    font-size: 0.86rem;
+  }
+
+  .privacy-toc a:hover,
+  .privacy-content a:hover {
+    color: var(--color-primary-deep);
+  }
+
+  .privacy-content {
+    min-width: 0;
+  }
+
+  .privacy-content section {
+    scroll-margin-top: calc(var(--header-height) + 28px);
+  }
+
+  .privacy-content section + section {
+    margin-top: 54px;
+  }
+
+  .privacy-content h2 {
+    margin-bottom: 18px;
+    font-family: var(--font-heading);
+    font-size: clamp(1.35rem, 3vw, 1.8rem);
+    line-height: 1.4;
+    letter-spacing: -0.02em;
+  }
+
+  .privacy-content p,
+  .privacy-content li {
+    color: var(--color-ink-soft);
+  }
+
+  .privacy-content p + p,
+  .privacy-content p + ul,
+  .privacy-content ul + p {
+    margin-top: 14px;
+  }
+
+  .privacy-content ul {
+    display: grid;
+    gap: 8px;
+    margin-bottom: 0;
+    padding-left: 1.4rem;
+  }
+
+  .privacy-content a {
+    color: #9b612b;
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-color: rgba(155, 97, 43, 0.35);
+    text-underline-offset: 4px;
+  }
+
+  .privacy-summary {
+    padding: clamp(24px, 4vw, 34px);
+    border: 1px solid rgba(214, 151, 76, 0.22);
+    border-radius: 24px;
+    background: var(--color-surface-accent);
+  }
+
+  .privacy-summary h2 {
+    font-size: 1.25rem;
+  }
+
+  .back-link {
+    display: inline-flex;
+    margin-top: 64px;
+  }
+
+  @media (max-width: 820px) {
+    .privacy-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .privacy-toc {
+      position: static;
+    }
+  }
+</style>

--- a/techguide/src/routes/sitemap.xml/+server.ts
+++ b/techguide/src/routes/sitemap.xml/+server.ts
@@ -13,6 +13,7 @@ const sitemapEntries = [
   { path: '/profile/academy-fes-2026/', changefreq: 'weekly', priority: '0.6' },
   { path: pageSeo.recruit.path, changefreq: 'weekly', priority: '0.7' },
   { path: pageSeo.macclipy.path, changefreq: 'weekly', priority: '0.8' },
+  { path: pageSeo.macclipyPrivacy.path, changefreq: 'monthly', priority: '0.4' },
   { path: pageSeo.contact.path, changefreq: 'monthly', priority: '0.7' },
 ] as const;
 

--- a/techguide/tsconfig.json
+++ b/techguide/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "allowJs": false,
+    "allowImportingTsExtensions": true,
     "checkJs": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## 概要

[techguide-jp/mac-clipy#31](https://github.com/techguide-jp/mac-clipy/issues/31) に向けて、MacClipyの匿名利用イベントを受け取るfirst-party API、GA4 Measurement Protocol転送、公開プライバシーポリシー、GA4運用手順を追加します。

## 既存実装の調整意図

- `POST /api/macclipy/analytics` はtransportに限定し、schema検証、レート制限、GA4転送をserver moduleへ分離しました。
- 既存のserver-only secret取得経路へ `MACCLIPY_GA_API_SECRET` を追加し、通常環境変数とAmplify SSMのどちらでも参照できます。
- 既存のGA4管理スクリプトを拡張し、アプリ版・build番号・macOSメジャー版・CPU種別をevent-scoped custom dimensionとして同期できます。
- MacClipy製品ページ、SEO情報、sitemapから `/macclipy/privacy/` へ到達できるようにしました。

## APIとプライバシー上の判断

- 許可するpayloadは、schema version、ランダムUUID、`install` / `daily_active`、アプリ版、build番号、macOSメジャー版、CPU種別、発生日時だけです。
- 未知のfield、クリップボード由来field、4 KiB超、JSON以外、72時間超の古いイベント、未来5分超のイベントを拒否します。
- 1アドレス・1分あたり10件、最大1万キーのbounded in-memory rate limitを設けました。
- GA4の `client_id` にはランダムUUIDを使い、広告関連の同意は明示的に拒否します。接続元IPや本文をGA4へ転送・ログ出力しません。
- API secretやpayloadをresponseへ含めず、転送失敗は本文なしの `503` とします。
- ポリシーには初期ON、アプリ内の停止手順、送信対象外データ、GA4/AWSの利用、GA4 14か月・アクセスログ30日以内の保持方針を明記しました。

## 本番反映時の作業

1. GA4のMeasurement Protocol API secretを `/amplify/shared/d1ei4wu36fr0u9/MACCLIPY_GA_API_SECRET` に保存する。
2. SSR Compute roleへ対象parameterの `ssm:GetParameter` を追加する。
3. GA4のイベント・ユーザーデータ保持を14か月、Hosting compute logsを30日以内に設定する。
4. `pnpm ga:sync:dry`、`pnpm ga:sync`、`pnpm ga:list` で4つのcustom dimensionを反映・確認する。
5. Measurement Protocol validation serverと検証用インストールで疎通を確認する。

詳細は `techguide/docs/macclipy-analytics.md` にまとめています。MacClipy側の匿名送信を有効にした配布版は、このPRのdeployとGA4設定確認後にreleaseします。

## 検証

- `pnpm test`（13件成功）
- `pnpm validate`
  - Prettier
  - ESLint
  - `svelte-check`（0 errors / 0 warnings）
  - production build
- ローカル実HTTP確認
  - 正常payload: `202 Accepted`
  - `/macclipy/privacy/`: ポリシー本文をSSR
  - `/sitemap.xml`: `https://techguide.jp/macclipy/privacy/` を掲載

Refs techguide-jp/mac-clipy#31
