### PR TITLE
fix: GA管理APIのFieldMask形式を修正

### DIFF
--- a/techguide/scripts/ga-admin-field-mask.d.mts
+++ b/techguide/scripts/ga-admin-field-mask.d.mts
@@ -1,0 +1,1 @@
+export function createUpdateMask(...paths: string[]): { paths: string[] };

--- a/techguide/scripts/ga-admin-field-mask.mjs
+++ b/techguide/scripts/ga-admin-field-mask.mjs
@@ -1,0 +1,3 @@
+export function createUpdateMask(...paths) {
+  return { paths };
+}

--- a/techguide/scripts/ga-admin.mjs
+++ b/techguide/scripts/ga-admin.mjs
@@ -1,4 +1,5 @@
 import { AnalyticsAdminServiceClient, protos } from '@google-analytics/admin';
+import { createUpdateMask } from './ga-admin-field-mask.mjs';
 
 const { KeyEvent, CustomDimension } = protos.google.analytics.admin.v1beta;
 
@@ -147,7 +148,7 @@ async function ensureKeyEvents(client, parent, dryRun) {
         );
       } else {
         await client.updateKeyEvent({
-          updateMask: 'counting_method',
+          updateMask: createUpdateMask('counting_method'),
           keyEvent: {
             name: existing.name,
             countingMethod: desired.countingMethod,
@@ -190,7 +191,7 @@ async function ensureCustomDimensions(client, parent, dryRun) {
         console.log(`[dry-run] update custom dimension metadata: ${desired.parameterName}`);
       } else {
         await client.updateCustomDimension({
-          updateMask: 'display_name,description',
+          updateMask: createUpdateMask('display_name', 'description'),
           customDimension: {
             name: existing.name,
             displayName: desired.displayName,

--- a/techguide/src/lib/server/macclipy/gaAdminFieldMask.test.ts
+++ b/techguide/src/lib/server/macclipy/gaAdminFieldMask.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createUpdateMask } from '../../../../scripts/ga-admin-field-mask.mjs';
+
+await test('GA Admin API用のFieldMaskをpaths配列で生成する', () => {
+  assert.deepEqual(createUpdateMask('display_name', 'description'), {
+    paths: ['display_name', 'description'],
+  });
+});


### PR DESCRIPTION
## 概要

- GA Admin API の更新時に `updateMask` を protobuf の `FieldMask` 形式で渡すよう修正
- FieldMask の生成を小さなヘルパーへまとめ、実 API と同じ形を固定する回帰テストを追加

## 既存実装の調整意図

- `scripts/ga-admin.mjs` は文字列の `updateMask` を渡していたため、MacClipy 匿名計測の本番設定同期で `Request message serialization failure` になりました。`{ paths: [...] }` 形式へ変更し、キーイベントやカスタムディメンションの既存項目更新が実 API でも通るようにしています。
- FieldMask の組み立てを `scripts/ga-admin-field-mask.mjs` に分離し、複数パスが1つの文字列へ結合される退行をテストで防ぎます。

## 検証

- 修正前に追加テストが失敗することを確認
- 修正後に追加テストが通ることを確認
- `pnpm validate`
- 実 GA4 property に対する `scripts/ga-admin.mjs sync` が成功することを確認

## 関連

- techguide-jp/mac-clipy#31 の本番ロールアウト中に検出
